### PR TITLE
Fixes a Stream already operated on exception

### DIFF
--- a/jave-core/src/main/java/ws/schild/jave/Encoder.java
+++ b/jave-core/src/main/java/ws/schild/jave/Encoder.java
@@ -584,7 +584,9 @@ public class Encoder {
         } catch (IOException e) {
             throw new EncoderException(e);
         } finally {
-            ffmpeg.destroy();
+        	if (ffmpeg != null) {
+        		ffmpeg.destroy();
+        	}
             ffmpeg = null;
         }
     }

--- a/jave-core/src/main/java/ws/schild/jave/encode/EncodingArgument.java
+++ b/jave-core/src/main/java/ws/schild/jave/encode/EncodingArgument.java
@@ -11,6 +11,13 @@ import java.util.stream.Stream;
  */
 public interface EncodingArgument {
 
+	/**
+	 * Gets the Stream of arguments given the EncodingAttributes as context. Implementers must take
+	 * care to return a new Stream on each successive call as doing otherwise will result in the stream
+	 * already being operated on exceptions.
+	 * @param context
+	 * @return
+	 */
 	public Stream<String> getArguments(EncodingAttributes context);
 
 	public ArgType getArgType();

--- a/jave-core/src/main/java/ws/schild/jave/encode/PredicateArgument.java
+++ b/jave-core/src/main/java/ws/schild/jave/encode/PredicateArgument.java
@@ -1,6 +1,7 @@
 package ws.schild.jave.encode;
 
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -12,7 +13,7 @@ import java.util.stream.Stream;
 public class PredicateArgument implements EncodingArgument {
 
 	private ArgType argumentType;
-	private Stream<String> arguments;
+	private Supplier<Stream<String>> arguments;
 	private Predicate<EncodingAttributes> predicate;
 	
 	public PredicateArgument(
@@ -21,7 +22,7 @@ public class PredicateArgument implements EncodingArgument {
 		Predicate<EncodingAttributes> predicate) 
 	{
 		this.argumentType = argType;
-		this.arguments = Stream.of(argument);
+		this.arguments = () -> Stream.of(argument);
 		this.predicate = predicate;
 	}
 	
@@ -32,14 +33,14 @@ public class PredicateArgument implements EncodingArgument {
 		Predicate<EncodingAttributes> predicate) 
 	{
 		this.argumentType = argType;
-		this.arguments = Stream.of(argument1, argument2);
+		this.arguments = () -> Stream.of(argument1, argument2);
 		this.predicate = predicate;
 	}
 	
 	@Override
 	public Stream<String> getArguments(EncodingAttributes context) {
 		if (predicate.test(context)) {
-			return arguments;
+			return arguments.get();
 		} else {
 			return Stream.empty();
 		}

--- a/jave-core/src/main/java/ws/schild/jave/process/ffmpeg/DefaultFFMPEGLocator.java
+++ b/jave-core/src/main/java/ws/schild/jave/process/ffmpeg/DefaultFFMPEGLocator.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ws.schild.jave.Version;
 import ws.schild.jave.process.ProcessLocator;
 import ws.schild.jave.process.ProcessWrapper;
 


### PR DESCRIPTION
All implementers of EncodingArgument must return a new Stream. This is now noted in comments.