### PR TITLE
fix(ws.schild.jave.filters): Couldn't run in windows with OverlayWatermark filter

### DIFF
--- a/jave-core/src/main/java/ws/schild/jave/filters/Filter.java
+++ b/jave-core/src/main/java/ws/schild/jave/filters/Filter.java
@@ -34,6 +34,7 @@ public class Filter implements VideoFilter {
   private List<String> orderedArguments;
   private Map<String, String> namedArguments;
   private List<String> outputLinkLabels;
+  private String quoteCharacter = "\"";
 
   /**
    * Create a filter with the specified name with no input/output labels or arguments.
@@ -101,16 +102,25 @@ public class Filter implements VideoFilter {
         + formatLinkLabels(outputLinkLabels);
   }
 
+  /**
+   * Set quoteCharacter of arguments for this filter, Default is double quote.
+   *
+   * @param quoteCharacter The quoteCharacter of arguments
+   */
+  public void setQuoteCharacter(String quoteCharacter) {
+    this.quoteCharacter = quoteCharacter;
+  }
+
   private static String formatLinkLabels(List<String> labels) {
     return labels.stream().map(labelName -> "[" + labelName + "]").collect(Collectors.joining());
   }
 
   private String formatArguments() {
-    return ((orderedArguments.size() + namedArguments.size() > 0) ? "='" : "")
-        + Stream.concat(
-                orderedArguments.stream(),
-                namedArguments.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()))
+    return ((orderedArguments.size() + namedArguments.size() > 0) ? "=" + this.quoteCharacter : "")
+            + Stream.concat(
+            orderedArguments.stream(),
+            namedArguments.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()))
             .collect(Collectors.joining(":"))
-        + ((orderedArguments.size() + namedArguments.size() > 0) ? "'" : "");
+            + ((orderedArguments.size() + namedArguments.size() > 0) ? this.quoteCharacter : "");
   }
 }

--- a/jave-core/src/main/java/ws/schild/jave/filters/MovieFilter.java
+++ b/jave-core/src/main/java/ws/schild/jave/filters/MovieFilter.java
@@ -10,11 +10,30 @@ public class MovieFilter extends Filter {
    */
   public MovieFilter(File source) {
     super("movie");
-    addOrderedArgument(source.getAbsolutePath());
+    /*
+     * Need escaping special characters []\':,;
+     */
+    addOrderedArgument(escapingPath(source.getAbsolutePath()));
   }
 
   public MovieFilter(File source, String outputLabel) {
     this(source);
     addOutputLabel(outputLabel);
+  }
+
+  /**
+   *  escaping special characters for file path. <a hrer="https://ffmpeg.org/ffmpeg-filters.html#Notes-on-filtergraph-escaping">Notes on filtergraph escaping</a>
+   *
+   * @param filePath unescaped file path
+   * @return escaped file path
+   */
+  private String escapingPath(String filePath) {
+    return filePath.replaceAll("\\\\","\\\\\\\\")
+            .replaceAll("\\[", "\\\\[")
+            .replaceAll("]", "\\\\]")
+            .replaceAll("'", "\\\\\\\\\\\\'")
+            .replaceAll(":","\\\\\\\\:")
+            .replaceAll(",","\\\\,")
+            .replaceAll(";","\\\\;");
   }
 }


### PR DESCRIPTION
Follow the instructions in the document of ffmpeg, escaping special characters \':[],; for Filtergraph.
Set double quotes as default quote character of 'ws.schild.jave.filters.Filter'

Closes https://github.com/a-schild/jave2/issues/125