### PR TITLE
Fix version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It includes all binaries for the supported platforms
 <dependency>
  <groupId>ws.schild</groupId>
  <artifactId>jave-all-deps</artifactId>
- <version>3.1.0</version>
+ <version>3.0.1</version>
 </dependency>
 ```
 
@@ -60,7 +60,7 @@ Include the following in your pom files.
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-core</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ and then the specific jar(s) for your platform(s) :
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-nativebin-linux64</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -80,7 +80,7 @@ and then the specific jar(s) for your platform(s) :
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-nativebin-linux-arm64</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -89,7 +89,7 @@ and then the specific jar(s) for your platform(s) :
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-nativebin-linux-arm32</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -98,7 +98,7 @@ and then the specific jar(s) for your platform(s) :
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-nativebin-win64</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -107,7 +107,7 @@ and then the specific jar(s) for your platform(s) :
 <dependency>
     <groupId>ws.schild</groupId>
     <artifactId>jave-nativebin-osx64</artifactId>
-    <version>3.1.0</version>
+    <version>3.0.1</version>
 </dependency>
 ```
 
@@ -116,13 +116,13 @@ and then the specific jar(s) for your platform(s) :
 It includes all binaries for the supported platforms
 
 ``` XML
-compile group: 'ws.schild', name: 'jave-all-deps', version: '3.1.0'
+compile group: 'ws.schild', name: 'jave-all-deps', version: '3.0.1'
 ```
 
 ### For one platform only (Linux 64Bit in this case)
 ``` XML
-compile group: 'ws.schild', name: 'jave-core', version: '3.1.0'
-compile group: 'ws.schild', name: 'jave-nativebin-linux64', version: '3.1.0'
+compile group: 'ws.schild', name: 'jave-core', version: '3.0.1'
+compile group: 'ws.schild', name: 'jave-nativebin-linux64', version: '3.0.1'
 ```
 
 ### Main Components of Jave2


### PR DESCRIPTION
It looks like the latest version on Maven (https://search.maven.org/artifact/ws.schild/jave-all-deps) and the releases page (https://github.com/a-schild/jave2/releases) is `3.0.1` not `3.1.0` (which is what the README.md says).