### PR TITLE
Add bit depth of audio：s16 s16p s32 fltp dblp s64

### DIFF
--- a/jave-core/src/main/java/ws/schild/jave/MultimediaObject.java
+++ b/jave-core/src/main/java/ws/schild/jave/MultimediaObject.java
@@ -54,6 +54,12 @@ public class MultimediaObject {
   private static final Pattern CHANNELS_PATTERN =
       Pattern.compile("(mono|stereo|quad)", Pattern.CASE_INSENSITIVE);
 
+  /**
+   * This regexp is used to parse the ffmpeg output about the bit depth of an audio stream.
+   */
+  private static final Pattern BIT_DEPTH_PATTERN =
+          Pattern.compile("(s16|s16p|s32|fltp|dblp|s64)", Pattern.CASE_INSENSITIVE);
+
   /** The locator of the ffmpeg executable used by this extractor. */
   private final ProcessLocator locator;
 
@@ -359,6 +365,13 @@ public class MultimediaObject {
                       if (!parsed && m2.find()) {
                         int bitRate = Integer.parseInt(m2.group(1));
                         audio.setBitRate(bitRate * 1000);
+                        parsed = true;
+                      }
+                      // Bit depth
+                      m2 = BIT_DEPTH_PATTERN.matcher(token);
+                      if (!parsed && m2.find()) {
+                        String bitDepth = m2.group(1);
+                        audio.setBitDepth(bitDepth);
                         parsed = true;
                       }
                     }

--- a/jave-core/src/main/java/ws/schild/jave/info/AudioInfo.java
+++ b/jave-core/src/main/java/ws/schild/jave/info/AudioInfo.java
@@ -43,6 +43,10 @@ public class AudioInfo {
   /** The audio stream (average) bit rate. If less than 0, this information is not available. */
   private int bitRate = -1;
 
+
+  /** The audio stream bit depth. */
+  private String bitDepth;
+
   /** The video metadata. */
   private Map<String, String> metadata = new HashMap<>();
 
@@ -128,6 +132,25 @@ public class AudioInfo {
   }
 
   /**
+   * Returns the audio stream bit depth.
+   *
+   * @return The audio stream bit depth.
+   */
+  public String getBitDepth() {
+    return bitDepth;
+  }
+
+  /**
+   * Sets the audio stream bit depth.
+   *
+   * @param bitDepth The audio stream bit depth.
+   * @return this instance
+   */
+  public void setBitDepth(String bitDepth) {
+    this.bitDepth = bitDepth;
+  }
+
+  /**
    * Returns the audio metadata.
    *
    * @return The audio metadata.
@@ -150,14 +173,16 @@ public class AudioInfo {
   @Override
   public String toString() {
     return getClass().getName()
-        + " (decoder="
-        + decoder
-        + ", samplingRate="
-        + samplingRate
-        + ", channels="
-        + channels
-        + ", bitRate="
-        + bitRate
-        + ")";
+            + " (decoder="
+            + decoder
+            + ", samplingRate="
+            + samplingRate
+            + ", channels="
+            + channels
+            + ", bitRate="
+            + bitRate
+            + ", bitDepth="
+            + bitDepth
+            + ")";
   }
 }


### PR DESCRIPTION
Add the bit depth of the audio using the regex pattern "s16|s16p|s32|fltp|dblp|s64"

If you know something I've missed, please tell me. It would be better if you could upload the audio file for me to debug.